### PR TITLE
Fixing undefined variable

### DIFF
--- a/views/wk_html_to_pdf.php
+++ b/views/wk_html_to_pdf.php
@@ -230,7 +230,7 @@
 					break;
 				
 				default:
-					throw new Exception("Mode: " . $mode . " is not supported");
+					throw new Exception("Mode: " . $this->options['mode'] . " is not supported");
 			}
 
 			$filepath = $this->outputFile;


### PR DESCRIPTION
The default of the switch calls a variable $mode, which is never set. It appears that this should be $this->options['mode'] instead.
